### PR TITLE
Fix broken previous and next links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ and then enable it in your `config.toml`:
 theme = "book"
 ```
 
+## Usage
+To ensure that each page displays in the correct order, you should set the front-matter
+variables `order` and `weight` both to be equal to the page's position within its 
+subsection.  For example, section 4 and section 2.4 should both have a weight/order of
+4.
+
+Additionally, you should set the front-matter variable `sort_by = "order"` in any 
+section your create.
+
+Finally, you should create an `_index.md` file and (in addition to setting `sort_by = 
+"order"`) set the `redirect_to` front-matter variable to redirect to the first section
+of your content.  For example, if your first section has the slug `introduction`, then
+you would set `redirect_to = "introduction"`.
+
 ## Options
 
 ### Numbered chapters

--- a/templates/index.html
+++ b/templates/index.html
@@ -38,7 +38,7 @@
                                 </a>
                                 {% if subsection.pages %}
                                     <ul>
-                                        {% for page in subsection.pages %}
+                                        {% for page in subsection.pages | reverse %}
                                             <li {% if current_path == page.path %}class="active"{% endif %}>
                                                 <a href="{{ page.permalink }}">
                                                     {% if config.extra.book_number_chapters %}<strong>{{ chapter_num }}.{{ loop.index }}.</strong>{% endif %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -7,8 +7,8 @@
 {% endblock content %}
 
 {% block prev_link %}
-    {% if page.next %}
-        <a class="previous" href="{{ page.next.permalink }}"><</a>
+    {% if page.previous %}
+        <a class="previous" href="{{ page.previous.permalink }}"><</a>
     {% else %}
         {# No page before, find the link for the section it's in if there is one #}
         {% set index = get_section(path="_index.md") %}
@@ -23,8 +23,8 @@
 {% endblock prev_link %}
 
 {% block next_link %}
-    {% if page.previous %}
-        <a class="next" href="{{ page.previous.permalink }}">></a>
+    {% if page.next %}
+        <a class="next" href="{{ page.next.permalink }}">></a>
     {% else %}
         {# No page after, find the link for the following section #}
         {% set index = get_section(path="_index.md") %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -7,8 +7,8 @@
 {% endblock content %}
 
 {% block prev_link %}
-    {% if page.previous %}
-        <a class="previous" href="{{ page.previous.permalink }}"><</a>
+    {% if page.next %}
+        <a class="previous" href="{{ page.next.permalink }}"><</a>
     {% else %}
         {# No page before, find the link for the section it's in if there is one #}
         {% set index = get_section(path="_index.md") %}
@@ -23,8 +23,8 @@
 {% endblock prev_link %}
 
 {% block next_link %}
-    {% if page.next %}
-        <a class="next" href="{{ page.next.permalink }}">></a>
+    {% if page.previous %}
+        <a class="next" href="{{ page.previous.permalink }}">></a>
     {% else %}
         {# No page after, find the link for the following section #}
         {% set index = get_section(path="_index.md") %}

--- a/templates/section.html
+++ b/templates/section.html
@@ -16,7 +16,7 @@
         {% else %}
             {% if found_current %}
                 {% if subsection.pages %}
-                    {% set last_page = subsection.pages | last %}
+                    {% set last_page = subsection.pages | first %}
                     <a class="previous" href="{{ last_page.permalink }}"><</a>
                 {% else %}
                     <a class="previous" href="{{ subsection.permalink }}"><</a>
@@ -30,7 +30,7 @@
 
 {% block next_link %}
     {% if section.pages %}
-        {% set next_page = section.pages | first %}
+        {% set next_page = section.pages | last %}
         <a class="next" href="{{ next_page.permalink }}">></a>
     {% else %}
         {# No page in the section, find the link for the following section #}


### PR DESCRIPTION
The existing `previous` and `next` links seem to point in the wrong directions.  They are `next` and `previous` in a blog order (i.e., chronology), but the sidebar menu presents the links in descending order.  This could also be fixed by changing the order in the sidebar
menu, but this fix seems more straightforward.

To see a demo of the existing, broken functionality, see [this demo site](https://book--gutenberg-theme-demo.netlify.com/common_programming_concepts/how-functions-work/).  Pressing the `previous` arrow from section 4.3 *should* take you to 4.2 but actually takes you to 4.4.  The `next` arrow is similarly broken.