### PR TITLE
Add content to homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -68,6 +68,12 @@
 
             <div class="page__content">
                 {% block content %}
+                  {% if section.content %}
+                    {{ section.content | safe }}
+                  {% else %}
+                    {# the content of the following subsection #}
+                    {{ index.subsections[0].content | safe }}
+                  {% endif %}
                 {% endblock content %}
             </div>
 


### PR DESCRIPTION
The current `index.html` template does not provide any content for the
homepage—it leaves the body of the page blank.  This does not seem to be
consistent with how other book-style themes work; they typically either
display the first section or, more rarely, display custom content.

This change would allow either behaviour: if any content is provided in
`_index.md`, it would display that content.  Otherwise, it would default
to displaying the first section.

Compare the existing functionality at the [demo site I put together](https://book--gutenberg-theme-demo.netlify.com/) (which displays a blank homepage) with the [Rust Book](https://doc.rust-lang.org/stable/book/second-edition/) (which displays the first section on the homepage).