### PR TITLE
update base_url to fix Netlify Redirect

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-base_url = "https://zola-book.netlify.com"
+base_url = "https://zola-book.netlify.app"
 compile_sass = true
 title = "book theme"
 description = "A book theme"


### PR DESCRIPTION
It seems Netlify is redirecting all of the .com to .app This is affecting the demo by making ever link redirect from .com to .app You can see yourself by navigating pages on the current demo.