### PR TITLE
Feature: (Option) Show current section pages only

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,11 @@ You can disable that by setting the `book_number_chapters` in `extra`:
 ```toml
 book_number_chapters = false
 ```
+
+### Current section pages only
+By default, the `book` theme will list all the pages in the current section.
+You can disable that by setting the `book_current_section_pages` in `extra`:
+
+```toml
+book_current_section_pages = false
+```

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ book_number_chapters = false
 
 ### Current section pages only
 By default, the `book` theme will list all the pages in the current section.
-You can disable that by setting the `book_current_section_pages` in `extra`:
+You can disable that by setting the `book_only_current_section_pages` in `extra`:
 
 ```toml
-book_current_section_pages = false
+book_only_current_section_pages = false
 ```

--- a/config.toml
+++ b/config.toml
@@ -10,3 +10,4 @@ highlight_theme = "css"
 
 [extra]
 book_number_chapters = true
+book_current_section_pages = false

--- a/config.toml
+++ b/config.toml
@@ -10,4 +10,4 @@ highlight_theme = "css"
 
 [extra]
 book_number_chapters = true
-book_current_section_pages = false
+book_only_current_section_pages = false

--- a/templates/index.html
+++ b/templates/index.html
@@ -36,31 +36,57 @@
             {% endblock before_menu %}
             <nav role="navigation">
                 <ul>
+                    
                     {% block menu %}
-                        {% set index = get_section(path="_index.md") %}
-                        {% for s in index.subsections %}
-                            {% set subsection = get_section(path=s) %}
-                            <li {% if current_path == subsection.path %}class="active"{% endif %}>
-                                {% set chapter_num = loop.index %}
-                                <a href="{{ subsection.permalink | safe }}">
-                                    {% if config.extra.book_number_chapters %}<strong>{{ chapter_num }}.</strong>{% endif %}
-                                    {{ subsection.title }}
-                                </a>
-                                {% if subsection.pages %}
-                                    <ul>
-                                        {% for page in subsection.pages %}
-                                            <li {% if current_path == page.path %}class="active"{% endif %}>
-                                                <a href="{{ page.permalink | safe }}">
-                                                    {% if config.extra.book_number_chapters %}<strong>{{ chapter_num }}.{{ loop.index }}.</strong>{% endif %}
-                                                    {{ page.title }}
-                                                </a>
-                                            </li>
-                                        {% endfor %}
-                                    </ul>
-                                {% endif %}
-                            </li>
+                    {% set index = get_section(path="_index.md") %}
+                    {% for s in index.subsections %}
+                        {% set subsection = get_section(path=s) %}
+                        
+                        {# Determine if this is the current subsection or if a page within it is active #}
+                        {% set is_active = false %}
+                        
+                        {% if current_path == subsection.path %}
+                            {% set is_active = true %}
+                        {% endif %}
+                        
+                        {% for p in subsection.pages %}
+                            {% if current_path == p.path %}
+                                {% set is_active = true %}
+                            {% endif %}
                         {% endfor %}
-                    {% endblock menu %}
+                        
+                        <!-- Debug info -->
+                        <!-- current_path: {{ current_path }} -->
+                        <!-- subsection.path: {{ subsection.path }} -->
+                        <!-- is_active: {{ is_active }} -->
+                        <!-- book_current_section_pages: {{ config.extra.book_current_section_pages }} -->
+                        
+                        <li {% if is_active %}class="active"{% endif %}>
+                            {% set chapter_num = loop.index %}
+                            <a href="{{ subsection.permalink | safe }}">
+                                {% if config.extra.book_number_chapters %}<strong>{{ chapter_num }}.</strong>{% endif %}
+                                {{ subsection.title }}
+                            </a>
+                
+                            {# Show pages if book_current_section_pages is false OR if this is the current subsection #}
+                            {% if subsection.pages and (not config.extra.book_current_section_pages or current_path == subsection.path or subsection.pages | filter(attribute="path", value=current_path) | length > 0) %}
+                                <ul>
+                                    {% for page in subsection.pages %}
+                                        <li {% if current_path == page.path %}class="active"{% endif %}>
+                                            <a href="{{ page.permalink | safe }}">
+                                                {% if config.extra.book_number_chapters %}
+                                                    <strong>{{ chapter_num }}.{{ loop.index }}.</strong>
+                                                {% endif %}
+                                                {{ page.title }}
+                                            </a>
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                            {% endif %}
+                        </li>
+                    {% endfor %}
+                {% endblock menu %}
+
                 </ul>
             </nav>
             {% block after_menu %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -55,12 +55,6 @@
                             {% endif %}
                         {% endfor %}
                         
-                        <!-- Debug info -->
-                        <!-- current_path: {{ current_path }} -->
-                        <!-- subsection.path: {{ subsection.path }} -->
-                        <!-- is_active: {{ is_active }} -->
-                        <!-- book_current_section_pages: {{ config.extra.book_current_section_pages }} -->
-                        
                         <li {% if is_active %}class="active"{% endif %}>
                             {% set chapter_num = loop.index %}
                             <a href="{{ subsection.permalink | safe }}">
@@ -68,8 +62,8 @@
                                 {{ subsection.title }}
                             </a>
                 
-                            {# Show pages if book_current_section_pages is false OR if this is the current subsection #}
-                            {% if subsection.pages and (not config.extra.book_current_section_pages or current_path == subsection.path or subsection.pages | filter(attribute="path", value=current_path) | length > 0) %}
+                            {# Show pages if book_only_current_section_pages is false OR if this is the current subsection #}
+                            {% if subsection.pages and (not config.extra.book_only_current_section_pages or current_path == subsection.path or subsection.pages | filter(attribute="path", value=current_path) | length > 0) %}
                                 <ul>
                                     {% for page in subsection.pages %}
                                         <li {% if current_path == page.path %}class="active"{% endif %}>

--- a/theme.toml
+++ b/theme.toml
@@ -7,6 +7,7 @@ demo = "https://getzola.github.io/book/"
 
 [extra]
 book_number_chapters = true
+book_current_section_pages = false
 
 [author]
 name = "Vincent Prouillet"

--- a/theme.toml
+++ b/theme.toml
@@ -7,7 +7,7 @@ demo = "https://getzola.github.io/book/"
 
 [extra]
 book_number_chapters = true
-book_current_section_pages = false
+book_only_current_section_pages = false
 
 [author]
 name = "Vincent Prouillet"


### PR DESCRIPTION
# Feature: (Option) Show current section pages only

Hello,

After reading #28 I decided to give it a try and came up with this solution.

I added a new extra option `book_current_section_pages` that when set to the default `false` changes nothing. But when set to `true` will only show the current section pages on the sidebar.

## Screenshots

Before or with `book_current_section_pages` option set to `false (default):

![image](https://github.com/user-attachments/assets/f2873be5-dd1b-49cd-b3bf-95df070db374)

After with `book_current_section_pages` options set to true:

![image](https://github.com/user-attachments/assets/c99421dd-5c78-41f2-bfae-2c87e5f04d8c)

![image](https://github.com/user-attachments/assets/80736f19-7e56-4dab-8f85-480c79c6085f)

Hope this helps!
