### PR TITLE
Replace `page.smaller` with `page.lower`

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -7,8 +7,8 @@
 {% endblock content %}
 
 {% block prev_link %}
-    {% if page.smaller %}
-        <a class="previous" href="{{ page.smaller.permalink | safe }}"><</a>
+    {% if page.lower %}
+        <a class="previous" href="{{ page.lower.permalink | safe }}"><</a>
     {% else %}
         {# No page before, find the link for the section it's in if there is one #}
         {% set parent = get_section(path=page.ancestors | reverse | first) %}


### PR DESCRIPTION
I was playing with this theme and found that my back arrows weren't working. A little digging revealed that page.smaller turned into page.lower in a more recent Zola release. You may have to update your minimum Zola requirement if you take this -- I didn't investigate that side of things. With this change, the theme works for me with current Zola.